### PR TITLE
Migrate audit config to new policy format

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -49,8 +49,10 @@
             "ergebnis/composer-normalize": true,
             "php-http/discovery": true
         },
-        "audit": {
-            "abandoned": "report"
+        "policy": {
+            "abandoned": {
+                "audit": "report"
+            }
         },
         "sort-packages": true
     },


### PR DESCRIPTION
Migrates config.audit to the unified config.policy object introduced in Composer 2.10. This prepares the project for Composer 2.11 and avoids future deprecation warnings.

https://blog.packagist.com/composer-2-10-release/
https://getcomposer.org/doc/06-config.md#audit-1